### PR TITLE
Added Customer Admin page

### DIFF
--- a/src/Customer/Admin/CustomerAccountAdmin.js
+++ b/src/Customer/Admin/CustomerAccountAdmin.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import '../../App.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import searchIcon from '../../resources/searchIcon.png';
+import SideBar from '../../SideBar/SideBar';
+import { Button, Container, Form, Row, Col } from 'react-bootstrap';
+import { Link } from 'react-router-dom'
+import PopUp from '../../PopUp';
+
+
+class CustomerAccountAdmin extends React.Component {
+
+    constructor() {
+        super();
+        this.state = {
+          show: false,
+          items : [
+                {url:'/Customer/Admin', title: 'Home'},
+            ],
+          children: 'Customer',
+          auth: 'Admin'
+        };
+      }
+
+    render() {
+        return (
+            <div className="row">
+                <div className="col-md-1"></div> 
+                <SideBar items={this.state.items}/>
+                <div className="col-md-8" style={{'margin-left':'80px'}}>
+                    <h2 className="PageTitle">View All Account</h2><br/>
+                    <div className="contents">
+                        <Form inline>
+                            <Form.Control as="select">
+                                <option value="30">Last 30 Days</option>
+                                <option value="60">Last 60 Days</option>
+                                <option value="90">Last 90 Days</option>
+                                <option value="120">Last 120 Days</option>
+                            </Form.Control>
+                            <Form.Control type='date' style={{'margin-left':'30px'}}/>
+                            <Form.Control type="text" placeholder="Search.." style={{'margin-left':'30px'}}></Form.Control>
+                            <Button type="submit" variant="outline-*" style={{'background':'none','margin-left':'5px'}}><img src={searchIcon} alt="Search"/></Button>
+                        </Form>
+                        <br/>
+                        <div className="ListAll">
+                                <table>
+                                    <tr>
+                                        <th>ID</th>
+                                        <th>Service Name</th>
+                                        <th>Price</th>
+                                        <th>Deposit</th>
+                                        <th>Total balance</th>
+                                        <th>Date</th>
+                                    </tr>
+                                    <tr>
+                                        <td>1</td>
+                                        <td>Body Clinic</td>
+                                        <td>-$100</td>
+                                        <td>+$300</td>
+                                        <td>$200</td>
+                                        <td>2021/01/11</td>
+                                    </tr>
+                                    <tr>
+                                        <td>2</td>
+                                        <td>Face Clinic</td>
+                                        <td>-$90</td>
+                                        <td>0</td>
+                                        <td>$0</td>
+                                        <td>2021/01/01</td>
+                                    </tr>
+                                </table>
+                                
+                                <br/>
+                            </div>
+                        <Container>
+                            <Row >
+                                <Col xs={8}></Col>
+                                <Col>
+                                    <Button variant="outline-info" href="/Customer/Admin/Profile">Back</Button>&nbsp;
+                                    <Button variant="outline-info" href="/Customer/Admin/Account/Edit">Edit Account</Button>
+                                </Col>
+                            </Row>
+                        </Container>
+                        <br/><br/>
+                    </div>
+                    <br/><br/>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default CustomerAccountAdmin;

--- a/src/Customer/Admin/CustomerAccountEditAdmin.js
+++ b/src/Customer/Admin/CustomerAccountEditAdmin.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import '../../App.css';
+import SideBar from '../../SideBar/SideBar';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import { Form, Row, Col, Container, Button } from 'react-bootstrap';
+
+class CustomerAccountEditAdmin extends React.Component {
+    state = {
+        items: [
+            {url:'/Customer/Admin', title: 'Home'},
+        ]
+    }
+    constructor(prop){
+        super(prop)
+    }
+
+    render() {
+        const button = {
+            'font-size': 'large',
+            'font-weight': 'bold',
+            color: 'black',
+            margin: '40px',
+            'text-align':'center',
+            background: 'none',
+        };
+        
+        return (
+            <div className="row">
+                <div className="col-md-1"></div>
+                <SideBar items={this.state.items}/>
+                <div class="col-md-8" style={{'margin-left':'80px'}}>
+                    <h2 className="PageTitle">Edit Account</h2><br/>
+                    <Container>
+                        <Form>
+                            <Form.Group as={Row}>
+                                <Form.Label column sm={2}>Service Name:</Form.Label>
+                                <Col sm={6}>
+                                    <Form.Control type="email" placeholder="Skin Therapy"></Form.Control>
+                                </Col>
+                            </Form.Group>
+                            <Form.Group as={Row}>
+                                <Form.Label column sm={2}>Service price:</Form.Label>
+                                <Col sm={6}>
+                                    <Form.Control type="text"></Form.Control>
+                                </Col>
+                            </Form.Group>
+                            <Form.Group as={Row}>
+                                <Form.Label column sm={2}>Deposit</Form.Label>
+                                <Col sm={6}>
+                                    <Form.Control type="text"></Form.Control>
+                                </Col>
+                            </Form.Group>
+                            <Form.Group as={Row}>
+                                <Form.Label column sm={2}>Date:</Form.Label>
+                                <Col sm={6}>
+                                <Form.Control type='date'/>
+                                </Col>
+                            </Form.Group>
+                            <Form.Group as={Row}>
+                                <Form.Label column sm={2}>Staff Name</Form.Label>
+                                <Col sm={6}>
+                                    <Form.Control type="text"></Form.Control>
+                                </Col>
+                            </Form.Group>
+                            <Row >
+                                <Col xs={2}></Col>
+                                <Col>
+                                    <Button variant="outline-info" href="/Customer/Admin/Account">Back</Button>&nbsp;
+                                    <Button variant="outline-info" href="/Customer/Admin/Account">Edit Account</Button>
+                                </Col>
+                            </Row>
+                        </Form>
+                    </Container>
+                    <br/>
+                </div>
+            </div>
+        )
+    }
+}
+
+export default CustomerAccountEditAdmin

--- a/src/Customer/Admin/CustomerHomeAdmin.js
+++ b/src/Customer/Admin/CustomerHomeAdmin.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import SideBar from '../../SideBar/SideBar';
+import '../../App.css';
+import searchIcon from '../../resources/searchIcon.png';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import { Form, Row, Col, Container, Button, Table } from 'react-bootstrap';
+
+class CustomerHomeAdmin extends React.Component {
+
+    state = {
+        items: [
+            {url:'/Customer/Admin', title: 'Home'},
+        ]
+    }
+    constructor(prop){
+        super(prop)
+    }
+
+    render() {
+        
+        return (
+            <div className="row">
+                <div className="col-md-1"></div> 
+                <SideBar items={this.state.items}/>
+                <div className="col-md-8" style={{'margin-left':'80px'}}>
+                    <h2 className="PageTitle">Hi, Staff.fullName</h2><hr/>
+                    <div className="contents">
+                        <Form inline>
+                            <Form.Control type="text" placeholder="Search customer" style={{'margin-left':'800px'}}></Form.Control>
+                            <Button type="submit" variant="outline-*" style={{'background':'none','margin-left':'5px'}}><img src={searchIcon} alt="Search"/></Button>
+                        </Form>
+                    </div>
+                    <h4 className="PageTitle">Customer List</h4><br/>
+                    <Table striped bordered hover>
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Customer Name</th>
+                            <th>Customer Balance</th>
+                            <th>Customer Level</th>
+                            <th>Detail</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>1</td>
+                            <td>Mintae Kim</td>
+                            <td>$199</td>
+                            <td>Normal</td>
+                            <td><a href="/Customer/Admin/Profile">Detail</a></td>
+                        </tr>
+                        <tr>
+                            <td>2</td>
+                            <td>Harry Potter</td>
+                            <td>$90</td>
+                            <td>VIP</td>
+                            <td><a href="/Customer/Admin/Profile">Detail</a></td>
+                        </tr>
+                    </tbody>
+                </Table>
+                </div>
+            </div>
+        )
+    }
+}
+
+export default CustomerHomeAdmin

--- a/src/Customer/Admin/CustomerProfileAdmin.js
+++ b/src/Customer/Admin/CustomerProfileAdmin.js
@@ -1,0 +1,97 @@
+import React from "react";
+import "../../App.css";
+import SideBar from "../../SideBar/SideBar";
+import "bootstrap/dist/css/bootstrap.min.css";
+import { Container, Form, Row, Col, Button } from "react-bootstrap";
+
+class CustomerProfileAdmin extends React.Component {
+  state = {
+    items: [
+        {url:'/Customer/Admin', title: 'Home'},
+    ],
+  };
+  constructor(prop) {
+    super(prop);
+  }
+
+  render() {
+    return (
+        <div className="row">
+        <div className="col-md-1"></div>
+        <SideBar items={this.state.items}/>
+        <div class="col-md-6" style={{'margin-left':'80px'}}>
+            <h2 className="PageTitle">User.userName Information</h2><hr/><br/>
+            <Container class="col-md-6">
+            <Form style={{'fontSize': '20px', 'marginLeft':'80px', 'textAlign' : 'left'}}>
+              <Form.Group as={Row}>
+                <Form.Label column md={3}>
+                  Name: 
+                </Form.Label>
+                <Col sm={1}>
+                  <Form.Label column md={0} >
+                      User.FullName
+                  </Form.Label>
+                </Col>
+              </Form.Group>
+              <Form.Group as={Row}>
+                <Form.Label column sm={3}>
+                  Email:
+                </Form.Label>
+                <Col sm={1}>
+                  <Form.Label column md={0}>
+                      User.Email
+                  </Form.Label>
+                </Col>
+              </Form.Group>
+              <Form.Group as={Row}>
+                <Form.Label column sm={3}>
+                  Address:
+                </Form.Label>
+                <Col sm={1}>
+                  <Form.Label column md={0}>
+                      User.Address
+                  </Form.Label>
+                </Col>
+              </Form.Group>
+              <Form.Group as={Row}>
+                <Form.Label column sm={3}>
+                  Current Balance:
+                </Form.Label>
+                <Col sm={1}>
+                  <Form.Label column md={0}>
+                      User.Balance
+                  </Form.Label>
+                </Col>
+              </Form.Group>
+              <Form.Group as={Row}>
+                <Form.Label column sm={3}>
+                  Customer level:
+                </Form.Label>
+                <Col sm={3}>
+                <Form.Control as="select">
+                    <option value="">Normal</option>
+                    <option value="">VIP</option>
+                </Form.Control>    
+                </Col>
+              </Form.Group>
+            </Form>
+          </Container>
+          <Container>
+          <Row >
+              <Col>
+                <Button variant="outline-info" href="/Appointment/Appointments">View Appointment</Button>&nbsp;
+                <Button variant="outline-info" href="/Request/">View Request</Button>&nbsp;
+                <Button variant="outline-info" href="/Customer/Admin/Account">View Account</Button>&nbsp;
+                <Button variant="outline-info" href="/Customer/Admin">Edit</Button>
+              </Col>
+                
+            </Row>
+          </Container>
+            <br/>
+        </div>
+    </div>
+    );
+  }
+}
+
+export default CustomerProfileAdmin;

--- a/src/RouterConfig.js
+++ b/src/RouterConfig.js
@@ -18,6 +18,10 @@ import CustomerProfile from './Customer/CustomerProfile';
 import CustomerEdit from './Customer/CustomerProfileEdit';
 import CustomerBalance from './Customer/CustomerBalance';
 import BalanceDetail from './Customer/BalanceDetail';
+import CustomerHomeAdmin from './Customer/Admin/CustomerHomeAdmin';
+import CustomerProfileAdmin from './Customer/Admin/CustomerProfileAdmin';
+import CustomerAccountAdmin from './Customer/Admin/CustomerAccountAdmin';
+import CustomerAccountEditAdmin from './Customer/Admin/CustomerAccountEditAdmin';
 import ViewRequest from './Request/ViewRequest';
 import RequestHomeAdmin from './Request/Admin/RequestHomebyAdmin';
 import AnswerRequest from './Request/Admin/AnswerRequest';
@@ -105,6 +109,11 @@ class RouterConfig extends React.Component {
               <Route exact path='/Customer/Balance' render={() => <CustomerBalance />} />
               <Route exact path='/Customer/BalanceDetail' render={() => <BalanceDetail />} />
               
+              {/* Customer Admin URL*/}
+              <Route exact path='/Customer/Admin' render={() => <CustomerHomeAdmin />} />
+              <Route exact path='/Customer/Admin/profile' render={() => <CustomerProfileAdmin />} />
+              <Route exact path='/Customer/Admin/Account' render={() => <CustomerAccountAdmin />} />
+              <Route exact path='/Customer/Admin/Account/Edit' render={() => <CustomerAccountEditAdmin />} />
               
               {/* Register URL */}
               <Route exact path='/Register/Login' render={() => <Login />} />


### PR DESCRIPTION
Fixes: #69 

### Description:
Added admin customer page to control customer level and save service history with account

### Screentshot:
Main -  Customer list
<img width="1529" alt="Screen Shot 2021-02-01 at 11 26 40 PM" src="https://user-images.githubusercontent.com/50645765/106552427-56b62c80-64e5-11eb-8977-4ec9f4c4e215.png">

Customer Information and change level. also, connect with appointment and requirement
<img width="836" alt="Screen Shot 2021-02-01 at 11 26 51 PM" src="https://user-images.githubusercontent.com/50645765/106552517-7f3e2680-64e5-11eb-881b-f15b55547102.png">

Account list
<img width="1161" alt="Screen Shot 2021-02-01 at 11 27 00 PM" src="https://user-images.githubusercontent.com/50645765/106552533-86653480-64e5-11eb-8f98-5381040191ea.png">

Add new history
<img width="923" alt="Screen Shot 2021-02-01 at 11 27 06 PM" src="https://user-images.githubusercontent.com/50645765/106552550-8e24d900-64e5-11eb-8fab-9aacf80a3a5a.png">

