### PR TITLE
Add: after deleting appointment pages

### DIFF
--- a/src/Appointment/Admin/AppointmentAdmin.js
+++ b/src/Appointment/Admin/AppointmentAdmin.js
@@ -18,6 +18,7 @@ class AppointmentAdmin extends React.Component {
             ],
             show: false,
             children: 'appointment',
+            deletedLink: '/Appointment/Admin/Deleted',
         }
         this.showModal = this.showModal.bind(this);
         this.hideModal = this.hideModal.bind(this);
@@ -101,7 +102,7 @@ class AppointmentAdmin extends React.Component {
                                 <Button variant="outline-info" href="/Appointment/Admin/Message">Leave Message</Button>{' '}
                                 <Button variant="outline-danger" onClick={this.showModal}>Delete</Button>{' '}
                                 <Button variant="outline-info" href="/Appointment/Admin/Edit">Edit</Button></Col>
-                                <PopUp show={this.state.show} handleClose={this.hideModal} handleDelete={this.hideModal} text={this.state.children} btn1='Cancel' btn2='Delete' />
+                                <PopUp show={this.state.show} link={this.state.deletedLink} handleClose={this.hideModal} handleDelete={this.hideModal} text={this.state.children} btn1='Cancel' btn2='Delete' />
                         </Row>
                     </Container>
                 </div>

--- a/src/Appointment/Admin/AppointmentDeletedAdmin.js
+++ b/src/Appointment/Admin/AppointmentDeletedAdmin.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { Container, Row, Col, Button } from "react-bootstrap";
+import "../../App.css";
+import "bootstrap/dist/css/bootstrap.min.css";
+import SideBar from "../../SideBar/SideBar";
+
+class AppointmentDeletedAdmin extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      items: [
+        { url: "/Appointment", title: "Appointment Home" },
+        { url: "/Appointment/Admin/Appointments", title: "View All Appointments" },
+        { url: "/Appointment/Admin/Create", title: "Create Appointment" },
+      ],
+    };
+  }
+
+  componentDidMount() {
+    document.title = "Appointment Deleted | Body Contouring Clinic";
+  }
+
+  render() {
+    return (
+      <>
+        <div className="row">
+          <div className="col-md-1"></div>
+          <SideBar items={this.state.items} />
+          <div className="col-md-6">
+            <h1 style={{ margin: "100px" }}>Appointment Deleted!</h1>
+            <Container>
+              <Row>
+                <Col>
+                  <Button
+                    variant="outline-info"
+                    href="/Appointment/Admin/Appointments"
+                  >
+                    Back to Appointment List
+                  </Button>
+                </Col>
+                <Col>
+                  <Button variant="outline-info" href="/Appointment/Admin/Create">
+                    Create Appointment
+                  </Button>
+                </Col>
+              </Row>
+              <br />
+              <br />
+            </Container>
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+export default AppointmentDeletedAdmin;

--- a/src/Appointment/Appointment.js
+++ b/src/Appointment/Appointment.js
@@ -22,6 +22,7 @@ class Appointment extends React.Component {
             msgModal: false,
             id: '04',
             message: "Dear Customer, Please don't wear silver earrings in this program.",
+            deletedLink: '/Appointment/Deleted',
         };
         this.showModal = this.showModal.bind(this);
         this.hideModal = this.hideModal.bind(this);
@@ -109,7 +110,7 @@ class Appointment extends React.Component {
                                 <ViewAppointmentMessage show={this.state.msgModal} text={this.state.message} appointmentId={this.state.id} />
                                 <Button variant="outline-danger" onClick={this.showModal}>Delete</Button>{' '}
                                 <Button variant="outline-info" href="/Appointment/Edit">Edit</Button></Col>
-                                <PopUp show={this.state.show} handleClose={this.hideModal} handleDelete={this.hideModal} text={this.state.children} btn1='Cancel' btn2='Delete' />        
+                                <PopUp show={this.state.show} handleClose={this.hideModal} handleDelete={this.hideModal} text={this.state.children} link={this.state.deletedLink} btn1='Cancel' btn2='Delete' />        
                         </Row>
                     </Container>
                 </div>

--- a/src/Appointment/AppointmentDeleted.js
+++ b/src/Appointment/AppointmentDeleted.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { Container, Row, Col, Button } from "react-bootstrap";
+import "../App.css";
+import "bootstrap/dist/css/bootstrap.min.css";
+import SideBar from "../SideBar/SideBar";
+
+class AppointmentDeleted extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      items: [
+        { url: "/Appointment", title: "Appointment Home" },
+        { url: "/Appointment/Appointments", title: "View All Appointments" },
+        { url: "/Appointment/Create", title: "Create Appointment" },
+      ],
+    };
+  }
+
+  componentDidMount() {
+    document.title = "Appointment Deleted | Body Contouring Clinic";
+  }
+
+  render() {
+    return (
+      <>
+        <div className="row">
+          <div className="col-md-1"></div>
+          <SideBar items={this.state.items} />
+          <div className="col-md-6">
+            <h1 style={{ margin: "100px" }}>Appointment Deleted!</h1>
+            <Container>
+              <Row>
+                <Col>
+                  <Button
+                    variant="outline-info"
+                    href="/Appointment/Appointments"
+                  >
+                    Back to Appointment List
+                  </Button>
+                </Col>
+                <Col>
+                  <Button variant="outline-info" href="/Appointment/Create">
+                    Create Appointment
+                  </Button>
+                </Col>
+              </Row>
+              <br />
+              <br />
+            </Container>
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+export default AppointmentDeleted;

--- a/src/PopUp.js
+++ b/src/PopUp.js
@@ -17,7 +17,7 @@ class PopUp extends React.Component {
 
           <Modal.Footer>
             <Button variant="secondary" onClick={this.props.handleClose}>{this.props.btn1}</Button>
-            <Button variant="primary" onClick={this.props.handleDelete}>{this.props.btn2}</Button>
+            <Button variant="primary" onClick={this.props.handleDelete} href={this.props.link}>{this.props.btn2}</Button>
           </Modal.Footer> 
         </Modal>
       );

--- a/src/RouterConfig.js
+++ b/src/RouterConfig.js
@@ -50,6 +50,8 @@ import openHours from './resources/openHours.png';
 import servicePic from './resources/SerivcePic.png';
 import ViewStaffSchedule from './StaffSchedule/ViewStaffSchedule';
 import EditStaffSchedule from './StaffSchedule/EditStaffSchedule';
+import AppointmentDeleted from './Appointment/AppointmentDeleted';
+import AppointmentDeletedAdmin from './Appointment/Admin/AppointmentDeletedAdmin';
 
 
 
@@ -71,13 +73,15 @@ class RouterConfig extends React.Component {
               <Route exact path='/Appointment/Create' render={() => <CreateAppointment />} />
               <Route exact path='/Appointment/Appointment' render={() => <Appointment />} />
               <Route exact path='/Appointment/Edit' render={() => <EditAppointment />} />
-              
+              <Route exact path='/Appointment/Deleted' render={() => <AppointmentDeleted />} />
+
               {/* Appointment Admin URL */}
               <Route exact path='/Appointment/Admin/Appointments' render={() => <AppointmentsAdmin />} />
               <Route exact path='/Appointment/Admin/Appointment' render={() => <AppointmentAdmin />} />
               <Route exact path='/Appointment/Admin/Edit' render={() => <EditAppointmentAdmin />} />
               <Route exact path='/Appointment/Admin/Create' render={() => <CreateAppointmentAdmin />} />
               <Route exact path='/Appointment/Admin/Message' render={() => <LeaveMessageToAppointment />} />
+              <Route exact path='/Appointment/Admin/Deleted' render={() => <AppointmentDeletedAdmin />} />
 
               {/* Staff Schedule URL */}
               <Route exact path='/Staff/Schedule' render={() => <ViewStaffSchedule />} />


### PR DESCRIPTION
In our mockup pages, there are pages **after** user deletes appointment. Like this,

![image](https://user-images.githubusercontent.com/50813726/106676209-72244480-6584-11eb-8585-e75847506aa3.png)

This PR adds deleted pages for admin appointment and customer appointment
![image](https://user-images.githubusercontent.com/50813726/106676180-689adc80-6584-11eb-84dd-1f5884228def.png)
