### PR TITLE
Fix Issues #244 #245 - remove checkboxes in request homes and add back detail page in request admin

### DIFF
--- a/src/Request/Admin/AnswerRequest.js
+++ b/src/Request/Admin/AnswerRequest.js
@@ -69,7 +69,7 @@ class AnswerRequest extends React.Component {
         <Redirect
           push
           to={{
-            pathname: `/Request/Admin/${this.state.request._id}`,
+            pathname: `/Request/Admin/Details/${this.state.request._id}`,
           }}
         />
       );

--- a/src/Request/Admin/ListAllRequestbyAdmin.js
+++ b/src/Request/Admin/ListAllRequestbyAdmin.js
@@ -81,7 +81,7 @@ class ListAllRequestbyAdmin extends React.Component {
                     <input type="checkbox" />
                   </td>
                   <td>
-                    <Link to={`/Request/Admin/${request._id}`} style={{ color: 'black' }}>
+                    <Link to={`/Request/Admin/Details/${request._id}`} style={{ color: 'black' }}>
                       {request.title}
                     </Link>
                   </td>

--- a/src/Request/Admin/RequestHomebyAdmin.js
+++ b/src/Request/Admin/RequestHomebyAdmin.js
@@ -2,7 +2,7 @@ import React from 'react';
 import '../../App.css';
 import searchIcon from '../../resources/searchIcon.png';
 import SideBar from '../../SideBar/SideBar';
-import { Button, Container, Form, Row, Col } from 'react-bootstrap';
+import { Button, Form } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 
@@ -205,9 +205,6 @@ class RequestHomebyAdmin extends React.Component {
             <br />
             <table>
               <tr>
-                <th>
-                  <input type="checkbox" />
-                </th>
                 <th>Title</th>
                 <th>Category</th>
                 <th>Service</th>
@@ -224,10 +221,7 @@ class RequestHomebyAdmin extends React.Component {
                     : this.state.status == request.status) && (
                     <tr key={request._id}>
                       <td>
-                        <input type="checkbox" />
-                      </td>
-                      <td>
-                        <Link to={`/Request/Admin/Answer/${request._id}`} style={{ color: 'black' }}>
+                        <Link to={`/Request/Admin/Details/${request._id}`} style={{ color: 'black' }}>
                           {request.title}
                         </Link>
                       </td>
@@ -247,17 +241,6 @@ class RequestHomebyAdmin extends React.Component {
                   )
               )}
             </table>
-            <Container>
-              <Row>
-                <Col xs={10}></Col>
-                <Col xs={1}></Col>
-                <Col xs={1}>
-                  <Button variant="outline-info" href="/Request/Admin/Answer">
-                    Answer
-                  </Button>
-                </Col>
-              </Row>
-            </Container>
             <br />
             <br />
           </div>

--- a/src/Request/RequestHome.js
+++ b/src/Request/RequestHome.js
@@ -4,8 +4,7 @@ import searchIcon from '../resources/searchIcon.png';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 import SideBar from '../SideBar/SideBar';
-import { Button, Container, Form, Row, Col } from 'react-bootstrap';
-import PopUp from '../PopUp';
+import { Button, Form } from 'react-bootstrap';
 
 class RequestHome extends React.Component {
   constructor() {
@@ -206,10 +205,7 @@ class RequestHome extends React.Component {
             <br />
             <table>
               <tr>
-                <th>
-                  <input type="checkbox" value="selectAll" />
-                </th>
-                <th>title</th>
+                <th>Title</th>
                 <th>Category</th>
                 <th>Service</th>
                 <th>Created Date</th>
@@ -223,9 +219,6 @@ class RequestHome extends React.Component {
                   : this.state.status == request.status) && (
                 <tr key={request._id}>
                   <td>
-                    <input type="checkbox" value={request._id} />
-                  </td>
-                  <td>
                     <Link to={`/Request/Detail/${request._id}`} style={{ color: 'black' }}>
                       {request.title}
                     </Link>
@@ -238,31 +231,6 @@ class RequestHome extends React.Component {
                 </tr>
               ))}
             </table>
-            <Container>
-              <Row>
-                <Col xs={9}></Col>
-                <Col xs={1}>
-                  <Button variant="outline-info" href="/Request/Create">
-                    Create
-                  </Button>
-                </Col>
-                <Col xs={1}>
-                  <Button variant="outline-danger" onClick={this.showModal}>
-                    Delete
-                  </Button>
-                </Col>
-                <PopUp
-                  show={this.state.show}
-                  handleClose={this.hideModal}
-                  handleDelete={this.deleteReq}
-                  text={this.state.children}
-                  btn1="Cancel"
-                  btn2="Delete"
-                />
-              </Row>
-              <br />
-              <br />
-            </Container>
             <br />
             <br />
           </div>

--- a/src/RouterConfig.js
+++ b/src/RouterConfig.js
@@ -21,6 +21,7 @@ import CustomerAccountAdmin from './Customer/Admin/CustomerAccountAdmin';
 import CustomerAccountEditAdmin from './Customer/Admin/CustomerAccountEditAdmin';
 import ViewRequest from './Request/ViewRequest';
 import RequestHomeAdmin from './Request/Admin/RequestHomebyAdmin';
+import ViewRequestAdmin from './Request/Admin/ViewRequestDetails';
 import AnswerRequest from './Request/Admin/AnswerRequest';
 import EditRequest from './Request/EditRequest';
 import ViewFAQ from './Request/FAQ/ViewAllFAQbyGeneral';
@@ -165,6 +166,9 @@ class RouterConfig extends React.Component {
           {/* Request Admin URL*/}
           <Route exact path="/Request/Admin" render={() => <RequestHomeAdmin />} />
           <Route
+            path="/Request/Admin/Details/:id"
+            render={(props) => <ViewRequestAdmin id={props.match.params.id}></ViewRequestAdmin>}/>
+          <Route
             path="/Request/Admin/Answer/:id"
             render={(props) => <AnswerRequest id={props.match.params.id}></AnswerRequest>}
           />
@@ -191,7 +195,7 @@ class RouterConfig extends React.Component {
           <Route
             exact
             path="/Customer/Balance/:id"
-            render={(props) => <CustomerBalance  id={props.match.params.id}/>}
+            render={(props) => <CustomerBalance id={props.match.params.id} />}
           />
           <Route
             exact


### PR DESCRIPTION
Fixes: #245
### How to test
1. login as customer
2. go to `/Request`, you should not see any check boxes
3. log out, login again as staff
4. go to `/Request/Admin`, you should not see any check boxes
Fixes: #244 
1. login as staff
2. go to `/Request/Admin`, you should be seeing each title of request can be clicked
3. click the title
4. you should see the title brings you to request detail page (lots of fields), not answer page (only 3 fields)