### PR TITLE
issue-273: Updated UI Schedule design

### DIFF
--- a/src/StaffSchedule/ViewStaffScheduleCalendar.js
+++ b/src/StaffSchedule/ViewStaffScheduleCalendar.js
@@ -115,6 +115,7 @@ class ViewStaffScheduleCalendar extends React.Component {
           <div className="col-md-9">
             <Container style={{ marginLeft: '0px', marginRight: '0px', float: 'center' }}>
               <h2>Hi, {this.state.account.firstName + ' ' + this.state.account.lastName}, here is your schedule</h2>
+              <hr/><br/>
               <SavedPopUp
                 show={this.state.saveModal}
                 handelClose={this.hideSave}
@@ -131,16 +132,6 @@ class ViewStaffScheduleCalendar extends React.Component {
                   />
                 </Col>
               </Row>
-              {/* <br/>
-              <Row>
-                <Col>
-                  <StaffScheduleCalendar
-                    view={this.state.dayCalendarView}
-                    schedule={this.state.schedules}
-                    today={this.state.today}
-                  />
-                </Col>
-              </Row> */}
             </Container>
             <br />
             <br />

--- a/src/StaffSchedule/ViewStaffScheduleCalendar.js
+++ b/src/StaffSchedule/ViewStaffScheduleCalendar.js
@@ -123,14 +123,6 @@ class ViewStaffScheduleCalendar extends React.Component {
                 button={this.state.button}
               />
               <Row>
-                <Col sm={5}>
-                  <StaffScheduleCalendar
-                    view={this.state.dayCalendarView}
-                    schedule={this.state.schedules}
-                    today={this.state.today}
-                  />
-                </Col>
-                <Col sm={2}></Col>
                 <Col>
                   <StaffScheduleCalendar
                     view={this.state.weekCalendarView}
@@ -139,6 +131,16 @@ class ViewStaffScheduleCalendar extends React.Component {
                   />
                 </Col>
               </Row>
+              {/* <br/>
+              <Row>
+                <Col>
+                  <StaffScheduleCalendar
+                    view={this.state.dayCalendarView}
+                    schedule={this.state.schedules}
+                    today={this.state.today}
+                  />
+                </Col>
+              </Row> */}
             </Container>
             <br />
             <br />


### PR DESCRIPTION
This is my UI design suggestion for Staff WorkSchedule. 

The current version has two calendars in a two-divided screen but I think the Weekly calendar can cover all staff work schedule. 

This is simply the suggestion, I am okay if this PR is cancelled. 

![image](https://user-images.githubusercontent.com/50673489/111862636-e6485b00-892c-11eb-9b08-8f0cdf0e99a6.png)
