### PR TITLE
Only display date after today for create and edit

### DIFF
--- a/src/Appointment/Admin/CreateAppointmentAdminbyStaff.js
+++ b/src/Appointment/Admin/CreateAppointmentAdminbyStaff.js
@@ -20,13 +20,13 @@ class CreateAppointmentAdmin extends React.Component {
         specialRequest: String,
         service: String,
         schedule: String,
-        confirmation: "false",
+        confirmation: 'false',
       },
       services: [],
       customers: [],
       filterData: [],
-      technicians:[],
-      dateData:[],
+      technicians: [],
+      dateData: [],
     };
     this.showSave = this.showSave.bind(this);
     this.hideSave = this.hideSave.bind(this);
@@ -35,104 +35,103 @@ class CreateAppointmentAdmin extends React.Component {
   handlSubmit(event) {
     console.log(this.state.appointment);
     event.preventDefault();
-    fetch(`${process.env.REACT_APP_API_URL}/create-appointment`,{
-      method: "POST",
+    fetch(`${process.env.REACT_APP_API_URL}/create-appointment`, {
+      method: 'POST',
       body: JSON.stringify(this.state.appointment),
       headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },})
-    .then((response) => (response.json()))
-    .then(()=> this.setState({completed: true}))
-    .catch((err) => (console.log(err)));
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then(() => this.setState({ completed: true }))
+      .catch((err) => console.log(err));
   }
 
-  onCustomerChange(event){
+  onCustomerChange(event) {
     this.setState(() => ({
-      appointment:{
+      appointment: {
         ...this.state.appointment,
         customer: event.target.value,
-      }
+      },
     }));
   }
 
-  onServiceChange(event){
+  onServiceChange(event) {
     this.setState(() => ({
-      appointment:{
+      appointment: {
         ...this.state.appointment,
         service: event.target.value,
-      }
+      },
     }));
   }
 
-  onContactNumChange(event){
+  onContactNumChange(event) {
     this.setState(() => ({
-      appointment:{
+      appointment: {
         ...this.state.appointment,
         contactNumber: event.target.value,
-      }
+      },
     }));
   }
 
-  onSpecialRequestChange(event){
+  onSpecialRequestChange(event) {
     this.setState(() => ({
-      appointment:{
+      appointment: {
         ...this.state.appointment,
         specialRequest: event.target.value,
-      }
+      },
     }));
   }
 
-  onTechnicianChange(event){
+  onTechnicianChange(event) {
     console.log(event.target.value);
     fetch(`${process.env.REACT_APP_API_URL}/staffWorkSchedules?staff=${event.target.value}`)
-    .then(response => response.json())
-    .then((data)=>{
-      console.log(data);
-      this.setState({
-        filterData: data
-      })
-    });
+      .then((response) => response.json())
+      .then((data) => {
+        console.log(data);
+        this.setState({
+          filterData: data,
+        });
+      });
   }
 
-  onDateChange(event){
+  onDateChange(event) {
     // var pureDate = (event.target.value).split("-");
     // var searchDate = pureDate[1] + "/" + pureDate[2] +"/" + pureDate[0];
     console.log(event.target.value);
     fetch(`${process.env.REACT_APP_API_URL}/workSchedule?date=${event.target.value}`)
-    .then(response => response.json())
-    .then((data)=>{
-      console.log(data);
-      this.setState({
-        dateData: data
-      })
+      .then((response) => response.json())
+      .then((data) => {
+        console.log(data);
+        this.setState({
+          dateData: data,
+        });
+      });
+  }
+
+  onTimeChange(event) {
+    var finalWorkSchedule = {};
+    this.state.dateData.forEach(function (data) {
+      if (data.time._id == event.target.value) {
+        finalWorkSchedule = data;
+      }
+    });
+    this.setState({
+      appointment: {
+        ...this.state.appointment,
+        schedule: finalWorkSchedule,
+      },
     });
   }
 
-  onTimeChange(event){
-    var finalWorkSchedule = {};
-    this.state.dateData.forEach(function(data){
-
-        if(data.time._id == event.target.value)
-        {
-          finalWorkSchedule = data;
-        }
-    })
+  onScheduleChange(event) {
+    console.log('id: ' + event.target.value);
     this.setState({
-      appointment:{
-        ...this.state.appointment,
-        schedule: finalWorkSchedule,
-      }
-  });
-  }
-
-  onScheduleChange(event){
-    console.log("id: "+event.target.value);
-    this.setState({
-      appointment:{
+      appointment: {
         ...this.state.appointment,
         schedule: event.target.value,
-      }
+      },
     });
   }
 
@@ -144,155 +143,175 @@ class CreateAppointmentAdmin extends React.Component {
     this.setState({ saveModal: false });
   };
 
-  getTechnicians(){
+  getTechnicians() {
     fetch(`${process.env.REACT_APP_API_URL}/staffs`)
-    .then(response => response.json())
-    .then((data)=>{
-      this.setState({
-        technicians: data
-      })
-      console.log(this.state.technicians);
-    });
+      .then((response) => response.json())
+      .then((data) => {
+        this.setState({
+          technicians: data,
+        });
+        console.log(this.state.technicians);
+      });
   }
 
   componentDidMount() {
     document.title = 'Create New Appointment | Body Contouring Clinic';
 
     fetch(`${process.env.REACT_APP_API_URL}/services`)
-    .then(response => response.json())
-    .then((data)=>{
-      this.setState({
-        services: data
-      })
-    });
+      .then((response) => response.json())
+      .then((data) => {
+        this.setState({
+          services: data,
+        });
+      });
 
     fetch(`${process.env.REACT_APP_API_URL}/customers`)
-    .then(response => response.json())
-    .then((data)=>{
-      this.setState({
-        customers: data,
-      })
-    });
+      .then((response) => response.json())
+      .then((data) => {
+        this.setState({
+          customers: data,
+        });
+      });
 
     this.getTechnicians();
   }
 
   render() {
-    if(this.state.completed)
-    {
-      return <Redirect push to={{
-        pathname: '/Appointment/Admin'
-      }}/>
+    if (this.state.completed) {
+      return (
+        <Redirect
+          push
+          to={{
+            pathname: '/Appointment/Admin',
+          }}
+        />
+      );
     }
     return (
-            <Container>
+      <Container>
+        <Row>
+          <Col></Col>
+          <Col xs={8}>
+            <Form onSubmit={this.handlSubmit.bind(this)} method="POST">
+              <Form.Group as={Row} controlId="customer">
+                <Form.Label column sm="4">
+                  Customer Name:
+                </Form.Label>
+                <Col sm="8">
+                  <Form.Control inline as="select" onChange={this.onCustomerChange.bind(this)}>
+                    <option value="">-- select customer --</option>
+                    {this.state.customers.map((result) => (
+                      // eslint-disable-next-line react/jsx-key
+                      <option value={result._id}>
+                        {result.account == null ? '' : result.account.firstName}{' '}
+                        {result.account == null ? '' : result.account.lastName}
+                      </option>
+                    ))}
+                  </Form.Control>
+                </Col>
+              </Form.Group>
+              <Form.Group as={Row} controlId="service">
+                <Form.Label column sm="4">
+                  Services:
+                </Form.Label>
+                <Col sm="8">
+                  <Form.Control inline as="select" onChange={this.onServiceChange.bind(this)}>
+                    <option value="">-- select service --</option>
+                    {this.state.services.map((result) => (
+                      // eslint-disable-next-line react/jsx-key
+                      <option value={result._id}>{result.name}</option>
+                    ))}
+                  </Form.Control>
+                </Col>
+              </Form.Group>
+              <Form.Group as={Row} controlId="schedule">
+                <Form.Label column sm="4">
+                  Technician:
+                </Form.Label>
+                <Col sm="8">
+                  <Form.Control as="select" onChange={this.onTechnicianChange.bind(this)}>
+                    <option value="">-- select technician --</option>
+                    {this.state.technicians.map((result) => (
+                      <option value={result._id}>
+                        {result.account.firstName} {result.account.lastName}
+                      </option>
+                    ))}
+                  </Form.Control>
+                </Col>
+              </Form.Group>
+              <Form.Group as={Row}>
+                <Form.Label column sm="4">
+                  Date
+                </Form.Label>
+                <Col sm="8">
+                  <Form.Control inline as="select" onChange={this.onDateChange.bind(this)}>
+                    <option value="">-- select Date --</option>
+                    {this.state.filterData.map(
+                      (result) =>
+                        // eslint-disable-next-line react/jsx-key
+                        moment(result.date.date).isAfter() && (
+                          <option value={result.date.date}>
+                            {moment(result.date.date).format('ll')}
+                          </option>
+                        )
+                    )}
+                  </Form.Control>
+                </Col>
+              </Form.Group>
+              <Form.Group as={Row}>
+                <Form.Label column sm="4">
+                  Time:
+                </Form.Label>
+                <Col sm="8">
+                  <Form.Control inline as="select" onChange={this.onTimeChange.bind(this)}>
+                    <option value="">-- select time --</option>
+                    {this.state.dateData.map((result) => (
+                      // eslint-disable-next-line react/jsx-key
+                      <option value={result.time._id}>{result.time.time}</option>
+                    ))}
+                  </Form.Control>
+                </Col>
+              </Form.Group>
+              <Form.Group as={Row}>
+                <Form.Label column sm="4">
+                  Contact Number:
+                </Form.Label>
+                <Col sm="8">
+                  <Form.Control
+                    placeholder="647-596-9521"
+                    onChange={this.onContactNumChange.bind(this)}
+                  />
+                </Col>
+              </Form.Group>
+              <Form.Group as={Row}>
+                <Form.Label column sm="4">
+                  Special Request:
+                </Form.Label>
+                <Col sm="8">
+                  <Form.Control
+                    as="textarea"
+                    rows={3}
+                    onChange={this.onSpecialRequestChange.bind(this)}
+                  />
+                </Col>
+              </Form.Group>
+              <br />
               <Row>
                 <Col></Col>
-                <Col xs={8}>
-                  <Form onSubmit={this.handlSubmit.bind(this)} method="POST">
-                    <Form.Group as={Row} controlId="customer">
-                      <Form.Label column sm="4">
-                        Customer Name:
-                      </Form.Label>
-                      <Col sm="8">
-                        <Form.Control inline as="select" onChange={this.onCustomerChange.bind(this)}>
-                          <option value="">-- select customer --</option>
-                          {this.state.customers.map((result)=>(
-                            // eslint-disable-next-line react/jsx-key
-                            <option value={result._id}>{result.account == null ? "" : result.account.firstName} {result.account == null ? "" : result.account.lastName}</option>
-                          ))}
-                        </Form.Control>
-                      </Col>
-                    </Form.Group>
-                    <Form.Group as={Row} controlId="service">
-                      <Form.Label column sm="4">
-                        Services:
-                      </Form.Label>
-                      <Col sm="8">
-                        <Form.Control inline as="select" onChange={this.onServiceChange.bind(this)}>
-                          <option value="">-- select service --</option>
-                          {this.state.services.map((result)=>(
-                            // eslint-disable-next-line react/jsx-key
-                            <option value={result._id}>{result.name}</option>
-                          ))}
-                        </Form.Control>
-                      </Col>
-                    </Form.Group>
-                    <Form.Group as={Row} controlId="schedule">
-                      <Form.Label column sm="4">
-                        Technician:
-                      </Form.Label>
-                      <Col sm="8">
-                        <Form.Control as="select" onChange={this.onTechnicianChange.bind(this)}>
-                          <option value="">-- select technician --</option>
-                          {this.state.technicians.map((result)=>(
-                            <option value={result._id}>{result.account.firstName} {result.account.lastName}</option>
-                          ))}
-
-                        </Form.Control>
-                      </Col>
-                    </Form.Group>
-                    <Form.Group as={Row}>
-                      <Form.Label column sm="4">
-                        Date
-                      </Form.Label>
-                      <Col sm="8">
-                        <Form.Control inline as="select" onChange={this.onDateChange.bind(this)}>
-                          <option value="">-- select Date --</option>
-                          {this.state.filterData.map((result)=>(
-                            // eslint-disable-next-line react/jsx-key
-                              <option value={result.date.date}>{moment(result.date.date).format('ll')}</option>
-                          ))}
-                          </Form.Control>
-                      </Col>
-                    </Form.Group>
-                    <Form.Group as={Row}>
-                      <Form.Label column sm="4">
-                        Time:
-                      </Form.Label>
-                      <Col sm="8">
-                        <Form.Control inline as="select" onChange={this.onTimeChange.bind(this)}>
-                          <option value="">-- select time --</option>
-                          {this.state.dateData.map((result)=>(
-                              // eslint-disable-next-line react/jsx-key
-                              <option value={result.time._id}>{result.time.time}</option>
-                          ))}
-                          </Form.Control>
-                      </Col>
-                    </Form.Group>
-                    <Form.Group as={Row}>
-                      <Form.Label column sm="4">
-                        Contact Number:
-                      </Form.Label>
-                      <Col sm="8">
-                        <Form.Control placeholder="647-596-9521" onChange={this.onContactNumChange.bind(this)}/>
-                      </Col>
-                    </Form.Group>
-                    <Form.Group as={Row}>
-                      <Form.Label column sm="4">
-                        Special Request:
-                      </Form.Label>
-                      <Col sm="8">
-                        <Form.Control as="textarea" rows={3} onChange={this.onSpecialRequestChange.bind(this)}/>
-                      </Col>
-                    </Form.Group>
-                    <br/>
-                    <Row>
-                      <Col></Col>
-                      <Col md="auto">
-                        <Button variant="outline-secondary" href="/Appointment/Admin">
-                          Cancel
-                        </Button>
-                      </Col>
-                      <Button variant="outline-info" type="submit">
-                        Save
-                      </Button>
-                    </Row>
-                  </Form>
+                <Col md="auto">
+                  <Button variant="outline-secondary" href="/Appointment/Admin">
+                    Cancel
+                  </Button>
                 </Col>
-                <Col></Col>
+                <Button variant="outline-info" type="submit">
+                  Save
+                </Button>
               </Row>
-            </Container>
+            </Form>
+          </Col>
+          <Col></Col>
+        </Row>
+      </Container>
     );
   }
 }

--- a/src/Appointment/CreateAppointmentbyStaff.js
+++ b/src/Appointment/CreateAppointmentbyStaff.js
@@ -226,16 +226,15 @@ class CreateAppointment extends React.Component {
                 <Col sm="8">
                   <Form.Control inline as="select" onChange={this.onDateChange.bind(this)}>
                     <option value="">-- select Date --</option>
-                    {this.state.filterData.map((result) => (
-                      // eslint-disable-next-line react/jsx-key
-                      <option value={result.date.date}>
-                        {moment(
-                          result.date.date.split('/')[2] +
-                            result.date.date.split('/')[0] +
-                            result.date.date.split('/')[1]
-                        ).format('ll')}
-                      </option>
-                    ))}
+                    {this.state.filterData.map(
+                      (result) =>
+                        // eslint-disable-next-line react/jsx-key
+                        moment(result.date.date).isAfter() && (
+                          <option value={result.date.date}>
+                            {moment(result.date.date).format('ll')}
+                          </option>
+                        )
+                    )}
                   </Form.Control>
                 </Col>
               </Form.Group>

--- a/src/StaffSchedule/CreateSchedule.js
+++ b/src/StaffSchedule/CreateSchedule.js
@@ -100,7 +100,9 @@ class CreateSchedule extends React.Component {
       });
     this.getDates().then((data) => {
       this.setState({
-        dates: data,
+        dates: data.filter((d) => {
+          return moment(d.date).isAfter();
+        }),
       });
     });
     this.getTimes().then((data) => {

--- a/src/StaffSchedule/EditStaffSchedule.js
+++ b/src/StaffSchedule/EditStaffSchedule.js
@@ -134,7 +134,9 @@ class EditStaffSchedule extends React.Component {
     });
     this.getDates().then((data) => {
       this.setState({
-        dates: data,
+        dates: data.filter((d) => {
+          return moment(d.date).isAfter();
+        }),
       });
     });
     this.getTimes().then((data) => {
@@ -155,28 +157,6 @@ class EditStaffSchedule extends React.Component {
         />
       );
     }
-    // today schedule
-    // let formatted = this.state.workSchedules.map(
-    //   (s) =>
-    //     new Object({
-    //       d: s.date.date.split('/'),
-    //       year: s.date.date.split('/')[2],
-    //       month: s.date.date.split('/')[0],
-    //       day: s.date.date.split('/')[1],
-    //       t: s.times.map(
-    //         (t) =>
-    //           new Object({
-    //             timeRange: t.time,
-    //             startHr: t.time.substr(0, t.time.indexOf(':')),
-    //             startMin: t.time.split(':')[1].split('-')[0],
-    //             endHr: t.time.split(':')[1].split('-')[1],
-    //             endMin: t.time.split(':')[2],
-    //           })
-    //       ),
-    //     })
-    // );
-    // make the date and time to this format (yyyy,mm-1,dd,hh,mm)
-    // week schedule
     return (
       <>
         <div className="row">

--- a/src/StaffSchedule/ViewScheduleDetail.js
+++ b/src/StaffSchedule/ViewScheduleDetail.js
@@ -21,6 +21,7 @@ class ViewScheduleDetail extends React.Component {
       date: [],
       time: [],
       show: false,
+      beforeToday: false,
     };
     this.showModal = this.showModal.bind(this);
     this.hideModal = this.hideModal.bind(this);
@@ -80,6 +81,11 @@ class ViewScheduleDetail extends React.Component {
         date: data.date,
         time: data.time,
       });
+      if (moment(data.date.date).isBefore()) {
+        this.setState({
+          beforeToday: true,
+        });
+      }
     });
   }
   render() {
@@ -107,7 +113,11 @@ class ViewScheduleDetail extends React.Component {
                   Date:
                 </Form.Label>
                 <Col sm={6}>
-                  <Form.Control type="text" readOnly value={moment(this.state.date.date).format('ll')} />
+                  <Form.Control
+                    type="text"
+                    readOnly
+                    value={moment(this.state.date.date).format('ll')}
+                  />
                 </Col>
               </Form.Group>
               <Form.Group as={Row}>
@@ -140,12 +150,14 @@ class ViewScheduleDetail extends React.Component {
                 <Row>
                   <Col xs={6}></Col>
                   <Col xs={1}>
-                    <Button
-                      variant="outline-info"
-                      href={`/Staff/Schedule/Edit/${this.state.workScheduleId}`}
-                    >
-                      Edit
-                    </Button>
+                    {!this.state.beforeToday && (
+                      <Button
+                        variant="outline-info"
+                        href={`/Staff/Schedule/Edit/${this.state.workScheduleId}`}
+                      >
+                        Edit
+                      </Button>
+                    )}
                   </Col>
                   <Col xs={1}>
                     <Button

--- a/src/StaffSchedule/ViewSchedulesList.js
+++ b/src/StaffSchedule/ViewSchedulesList.js
@@ -148,9 +148,9 @@ class ViewSchedulesList extends React.Component {
                       >
                         Details
                       </Button>{' '}
-                      <Button variant="outline-info" href={`/Staff/Schedule/Edit/${sch._id}`}>
+                      {/* <Button variant="outline-info" href={`/Staff/Schedule/Edit/${sch._id}`}>
                         Edit
-                      </Button>
+                      </Button> */}
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
Fixes: #297

### Test PR

#### Login as staff (56Vauseman)
Go to create schedule, you should only be able to select the date after today (it's meaningless to select the day before today)
Go to schedule list and choose detail for any schedule that is before today, you should not see edit button. (It's meaningless to edit past schedule)
Choose any schedule that is after today, you should be able to see edit button.

Go to create appointment by staff, no matter which staff you choose, you should only be able to see date after today in the dropdown. If you see nothing, that means this staff has no schedule, or her schedules are all before today.

#### Login as customer (ekim105)
Go to create appointment by staff, no matter which staff you choose, you should only be able to see date after today in the dropdown. If you see nothing, that means this staff has no schedule, or her schedules are all before today.