### PR TITLE
issue-296: set default currentBalance when new user signup

### DIFF
--- a/servers/handlers/accountHandler.js
+++ b/servers/handlers/accountHandler.js
@@ -9,6 +9,7 @@ exports.addNewAccount = function (data) {
   return new Promise((resolve, reject) => {
     let balance = new BalanceHistory({
       _id: new mongoose.Types.ObjectId(),
+      currentBalance: 0,
     });
     balance.save();
     var balanceH = `${balance._id}`;


### PR DESCRIPTION

1. SignUp
2. Login with Staff account
3. Go to Profile 
4. Go to Balance Management 
5. Search new user 
6. Check balance set 0 
7. Go to detail 
8. Check current balance set 0