### PR TITLE
Don't show booked schedule on creating appointment

### DIFF
--- a/models/workSchedule.js
+++ b/models/workSchedule.js
@@ -1,27 +1,33 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
-const WorkScheduleSchema = new Schema({
+const WorkScheduleSchema = new Schema(
+  {
     staff: {
-        type: Schema.Types.ObjectId,
-        ref: 'staffs',
-        required: true
+      type: Schema.Types.ObjectId,
+      ref: 'staffs',
+      required: true,
     },
     date: {
-        type: Schema.Types.ObjectId,
-        ref: 'dates',
-        required: true
+      type: Schema.Types.ObjectId,
+      ref: 'dates',
+      required: true,
     },
     time: {
-        type: Schema.Types.ObjectId,
-        ref: 'times',
+      type: Schema.Types.ObjectId,
+      ref: 'times',
     },
     description: {
-        type: String,
-    }
+      type: String,
+    },
+    booked: {
+      type: Boolean,
+      default: false
+    },
+  },
+  { timestamps: true }
+);
 
-}, { timestamps: true });
-
-const WorkSchedule = mongoose.model('workSchedules', WorkScheduleSchema)
+const WorkSchedule = mongoose.model('workSchedules', WorkScheduleSchema);
 
 module.exports = WorkSchedule;

--- a/src/Appointment/Admin/CreateAppointmentAdminbyStaff.js
+++ b/src/Appointment/Admin/CreateAppointmentAdminbyStaff.js
@@ -28,6 +28,9 @@ class CreateAppointmentAdmin extends React.Component {
       uniqueDates: [],
       technicians: [],
       dateData: [],
+      schedule: {
+        booked: 'true',
+      },
     };
     this.showSave = this.showSave.bind(this);
     this.hideSave = this.hideSave.bind(this);
@@ -45,6 +48,16 @@ class CreateAppointmentAdmin extends React.Component {
     })
       .then((response) => response.json())
       .then(() => this.setState({ completed: true }))
+      .catch((err) => console.log(err));
+    fetch(`${process.env.REACT_APP_API_URL}/workSchedule/${this.state.appointment.schedule._id}`, {
+      method: 'PUT',
+      body: JSON.stringify(this.state.schedule),
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
       .catch((err) => console.log(err));
   }
 
@@ -90,6 +103,7 @@ class CreateAppointmentAdmin extends React.Component {
         this.setState({
           filterData: data,
           uniqueDates: data
+            .filter(s => s.booked != true)
             .map((d) => d.date)
             .map(({ _id, date }) => ({ _id, date }))
             .filter((obj, pos, arr) => {
@@ -104,7 +118,7 @@ class CreateAppointmentAdmin extends React.Component {
       .then((response) => response.json())
       .then((data) => {
         this.setState({
-          dateData: data,
+          dateData: data.filter(d => d.booked != true),
         });
       });
   }
@@ -244,12 +258,11 @@ class CreateAppointmentAdmin extends React.Component {
                   <Form.Control inline as="select" onChange={this.onDateChange.bind(this)}>
                     <option value="">-- select Date --</option>
                     {this.state.uniqueDates.map(
-                      (result) => (
+                      (result) =>
                         // eslint-disable-next-line react/jsx-key
                         moment(result.date).isAfter() && (
-                        <option value={result.date}>{moment(result.date).format('ll')}</option>
-                      )
-                      )
+                          <option value={result.date}>{moment(result.date).format('ll')}</option>
+                        )
                     )}
                   </Form.Control>
                 </Col>

--- a/src/Appointment/CreateAppointmentbyStaff.js
+++ b/src/Appointment/CreateAppointmentbyStaff.js
@@ -29,6 +29,9 @@ class CreateAppointment extends React.Component {
       technicians: [],
       dateData: [],
       uniqueDates: [],
+      schedule: {
+        booked: 'true',
+      },
     };
     this.showSave = this.showSave.bind(this);
     this.hideSave = this.hideSave.bind(this);
@@ -54,6 +57,16 @@ class CreateAppointment extends React.Component {
     })
       .then((response) => response.json())
       .then(() => this.setState({ completed: true }))
+      .catch((err) => console.log(err));
+    fetch(`${process.env.REACT_APP_API_URL}/workSchedule/${this.state.appointment.schedule._id}`, {
+      method: 'PUT',
+      body: JSON.stringify(this.state.schedule),
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
       .catch((err) => console.log(err));
   }
 
@@ -92,6 +105,7 @@ class CreateAppointment extends React.Component {
         this.setState({
           filterData: data,
           uniqueDates: data
+            .filter((d) => d.booked != true)
             .map((d) => d.date)
             .map(({ _id, date }) => ({ _id, date }))
             .filter((obj, pos, arr) => {
@@ -106,7 +120,7 @@ class CreateAppointment extends React.Component {
       .then((response) => response.json())
       .then((data) => {
         this.setState({
-          dateData: data,
+          dateData: data.filter((s) => s.booked != true),
         });
       });
   }
@@ -116,6 +130,7 @@ class CreateAppointment extends React.Component {
     this.state.dateData.forEach(function (data) {
       if (data.time._id == event.target.value) {
         finalWorkSchedule = data;
+        console.log(data._id);
       }
     });
     this.setState({
@@ -124,6 +139,7 @@ class CreateAppointment extends React.Component {
         schedule: finalWorkSchedule,
       },
     });
+    // console.log(this.state)
   }
 
   onScheduleChange(event) {
@@ -170,6 +186,7 @@ class CreateAppointment extends React.Component {
   }
 
   render() {
+    console.log(this.state.uniqueDates);
     if (this.state.completed) {
       return (
         <Redirect
@@ -229,9 +246,7 @@ class CreateAppointment extends React.Component {
                       (result) =>
                         // eslint-disable-next-line react/jsx-key
                         moment(result.date).isAfter() && (
-                          <option value={result.date}>
-                            {moment(result.date).format('ll')}
-                          </option>
+                          <option value={result.date}>{moment(result.date).format('ll')}</option>
                         )
                     )}
                   </Form.Control>


### PR DESCRIPTION
Fixes: #363

#### Progress in this PR:
* Add booked field for schedule
* Only show unbooked date and time in create appointment by staff
* Once a new appointment is created, its schedule will be set to booked

#### How to test it

- Log in as staff
    - Go to create appointment by staff, in the dropdown, you should only see the date and the time that are **not** booked yet
    - Save the newly create appointment, and go to create another new appointment; in the dropdown, you should not see the time (or date, depends on if there is still available time slots on that date) that you just booked in the previous appointment.
- Log in as customer
    - Go to create appointment by staff, in the dropdown, you should only see the date and the time that are **not** booked yet
    - Save the newly create appointment, and go to create another new appointment; in the dropdown, you should not see the time (or date, depends on if there is still available time slots on that date) that you just booked in the previous appointment.